### PR TITLE
Performance of `hamming()` can be improved

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,14 +24,14 @@ pub type HammingResult = Result<usize, StrSimError>;
 /// }
 /// ```
 pub fn hamming(a: &str, b: &str) -> HammingResult {
-    if a.chars().count() != b.chars().count() {
-        Err(StrSimError::DifferentLengthArgs)
-    } else {
-        Ok(a.chars()
-            .zip(b.chars())
-            .filter(|&(a_char, b_char)| a_char != b_char)
-            .count())
-    }
+    let (mut ita, mut itb, mut cnt) = (a.chars(), b.chars(), 0);
+    loop{
+        match (ita.next(), itb.next()){
+            (Some(x), Some(y)) => if x != y {cnt+=1},
+            (None, None) => return Ok(cnt),
+            _ => return Err(StrSimError::DifferentLengthArgs),
+        } 
+    }   
 }
 
 /// Calculates the Jaro similarity between two strings. The returned value


### PR DESCRIPTION
`....chars().count()` iterates over whole string. It can be avoided.
```
tests::new_same_len ... bench:       4,756 ns/iter (+/- 74)
tests::old_same_len ... bench:       7,089 ns/iter (+/- 400)

tests::new_diff_len ... bench:       4,867 ns/iter (+/- 136)
tests::old_diff_len ... bench:       3,024 ns/iter (+/- 90)
```