### PR TITLE
Fix Damerau-Levenshtein

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Change Log
 This project attempts to adhere to [Semantic Versioning](http://semver.org).
 
+## [0.6.0] - (2016-12-26)
+### Added
+- Add optimal string alignment distance
+
+### Fixed
+- Fix Damerau-Levenshtein implementation (previous implementation was actually
+optimal string alignment; see this [Damerau-Levenshtein explanation])
+
 ## [0.5.2] - (2016-11-21)
 ### Changed
 - Remove Cargo generated documentation in favor of a [docs.rs] link
@@ -73,7 +81,8 @@ vector of results (thanks @ovarene)
 ### Added
 - Implement Hamming, Jaro, Jaro-Winkler, and Levenshtein
 
-[Unreleased]: https://github.com/dguo/strsim-rs/compare/0.5.2...HEAD
+[Unreleased]: https://github.com/dguo/strsim-rs/compare/0.6.0...HEAD
+[0.6.0]: https://github.com/dguo/strsim-rs/compare/0.5.2...0.6.0
 [0.5.2]: https://github.com/dguo/strsim-rs/compare/0.5.1...0.5.2
 [0.5.1]: https://github.com/dguo/strsim-rs/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/dguo/strsim-rs/compare/0.4.1...0.5.0
@@ -89,4 +98,6 @@ vector of results (thanks @ovarene)
 [0.1.1]: https://github.com/dguo/strsim-rs/compare/0.1.0...0.1.1
 [0.1.0]: https://github.com/dguo/strsim-rs/compare/fabad4...0.1.0
 [docs.rs]: https://docs.rs/strsim/
+[Damerau-Levenshtein explanation]:
+http://scarcitycomputing.blogspot.com/2013/04/damerau-levenshtein-edit-distance.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "strsim"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["Danny Guo <dannyguo91@gmail.com>"]
 description = """
 Implementations of string similarity metrics.

--- a/README.md
+++ b/README.md
@@ -2,31 +2,31 @@
 
 [Rust](https://www.rust-lang.org) implementations of [string similarity metrics]:
   - [Hamming]
-  - [Levenshtein] and [Damerau-Levenshtein]
+  - [Levenshtein]
+  - [Optimal string alignment]
+  - [Damerau-Levenshtein]
   - [Jaro and Jaro-Winkler] - this implementation of Jaro-Winkler does not limit the common prefix length
 
 ### Installation
-
 ```toml
 # Cargo.toml
 [dependencies]
-strsim = "0.5.2"
+strsim = "0.6.0"
 ```
 
 ### [Documentation](https://docs.rs/strsim/)
-
 You can change the version in the url to see the documentation for an older
 version in the
 [changelog](https://github.com/dguo/strsim-rs/blob/master/CHANGELOG.md).
 
 ### Usage
-
 ```rust
 extern crate strsim;
 
-use strsim::{hamming, levenshtein, damerau_levenshtein, jaro, jaro_winkler,
-             levenshtein_against_vec, damerau_levenshtein_against_vec,
-             jaro_against_vec, jaro_winkler_against_vec};
+use strsim::{hamming, levenshtein, osa_distance, damerau_levenshtein, jaro,
+             jaro_winkler, levenshtein_against_vec, osa_distance_against_vec,
+             damerau_levenshtein_against_vec, jaro_against_vec,
+             jaro_winkler_against_vec};
 
 fn main() {
     match hamming("hamming", "hammers") {
@@ -36,7 +36,9 @@ fn main() {
 
     assert_eq!(3, levenshtein("kitten", "sitting"));
 
-    assert_eq!(1, damerau_levenshtein("specter", "spectre"));
+    assert_eq!(3, osa_distance("ac", "cba"));
+
+    assert_eq!(2, damerau_levenshtein("ac", "cba"));
 
     assert!((0.392 - jaro("Friedrich Nietzsche", "Jean-Paul Sartre")).abs() <
             0.001);
@@ -45,13 +47,16 @@ fn main() {
             0.001);
 
     // get vectors of values back
-    let v = vec!["test", "test1", "test12", "test123", "", "tset"];
+    let v = vec!["test", "test1", "test12", "test123", "", "tset", "tsvet"];
 
     assert_eq!(levenshtein_against_vec("test", &v),
-               vec![0, 1, 2, 3, 4, 2]);
+               vec![0, 1, 2, 3, 4, 2, 3]);
+
+    assert_eq!(osa_distance_against_vec("test", &v),
+               vec![0, 1, 2, 3, 4, 1, 3]);
 
     assert_eq!(damerau_levenshtein_against_vec("test", &v),
-               vec![0, 1, 2, 3, 4, 1]);
+               vec![0, 1, 2, 3, 4, 1, 2]);
 
     let jaro_distances = jaro_against_vec("test", &v);
     let jaro_expected = vec![1.0, 0.933333, 0.888889, 0.857143, 0.0, 0.916667];
@@ -72,11 +77,11 @@ fn main() {
 ```
 
 ### Development
-
-Install [Vagrant](https://www.vagrantup.com), and run `vagrant up`.
+If you don't want to install Rust itself, you can install [Docker], and run
+`$ ./dev`. This should bring up a temporary container from which you can run
+[cargo] commands.
 
 ### License
-
 [MIT](https://github.com/dguo/strsim-rs/blob/master/LICENSE)
 
 [string similarity metrics]:http://en.wikipedia.org/wiki/String_metric
@@ -84,4 +89,7 @@ Install [Vagrant](https://www.vagrantup.com), and run `vagrant up`.
 [Jaro and Jaro-Winkler]:http://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance
 [Levenshtein]:http://en.wikipedia.org/wiki/Levenshtein_distance
 [Hamming]:http://en.wikipedia.org/wiki/Hamming_distance
+[Optimal string alignment]:https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance#Optimal_string_alignment_distance
+[Docker]:https://docs.docker.com/engine/installation/
+[cargo]:https://github.com/rust-lang/cargo
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,8 +1,9 @@
 extern crate strsim;
 
-use strsim::{hamming, levenshtein, damerau_levenshtein, jaro, jaro_winkler,
-             levenshtein_against_vec, damerau_levenshtein_against_vec,
-             jaro_against_vec, jaro_winkler_against_vec};
+use strsim::{hamming, levenshtein, osa_distance, damerau_levenshtein, jaro,
+             jaro_winkler, levenshtein_against_vec, osa_distance_against_vec,
+             damerau_levenshtein_against_vec, jaro_against_vec,
+             jaro_winkler_against_vec};
 
 #[test]
 fn hamming_works() {
@@ -18,8 +19,13 @@ fn levenshtein_works() {
 }
 
 #[test]
+fn osa_distance_works() {
+    assert_eq!(3, osa_distance("ac", "cba"));
+}
+
+#[test]
 fn damerau_levenshtein_works() {
-    assert_eq!(3, damerau_levenshtein("damerau", "aderua"));
+    assert_eq!(2, damerau_levenshtein("ac", "cba"));
 }
 
 #[test]
@@ -36,17 +42,25 @@ fn jaro_winkler_works() {
 
 #[test]
 fn levenshtein_against_vec_works() {
-   let v = vec!["test", "test1", "test12", "test123", "", "tset"];
+   let v = vec!["test", "test1", "test12", "test123", "", "tset", "tsvet"];
    let result = levenshtein_against_vec("test", &v);
-   let expected = vec![0, 1, 2, 3, 4, 2];
+   let expected = vec![0, 1, 2, 3, 4, 2, 3];
+   assert_eq!(expected, result);
+}
+
+#[test]
+fn osa_distance_against_vec_works() {
+   let v = vec!["test", "test1", "test12", "test123", "", "tset", "tsvet"];
+   let result = osa_distance_against_vec("test", &v);
+   let expected = vec![0, 1, 2, 3, 4, 1, 3];
    assert_eq!(expected, result);
 }
 
 #[test]
 fn damerau_levenshtein_against_vec_works() {
-   let v = vec!["test", "test1", "test12", "test123", "", "tset"];
+   let v = vec!["test", "test1", "test12", "test123", "", "tset", "tsvet"];
    let result = damerau_levenshtein_against_vec("test", &v);
-   let expected = vec![0, 1, 2, 3, 4, 1];
+   let expected = vec![0, 1, 2, 3, 4, 1, 2];
    assert_eq!(expected, result);
 }
 


### PR DESCRIPTION
Rename the original implementation to `osa_distance`, and implement the actual metric. Fixes #8 