### PR TITLE
Add some simple benchmarks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ fn main() {
 If you don't want to install Rust itself, you can run `$ ./dev` for a
 development CLI if you have [Docker] installed.
 
+Benchmarks require a Nightly toolchain. They are run by `cargo +nightly bench`.
+
 ### License
 [MIT](https://github.com/dguo/strsim-rs/blob/master/LICENSE)
 

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -1,0 +1,66 @@
+//! Benchmarks for strsim.
+
+#![feature(test)]
+
+extern crate strsim;
+
+mod benches {
+    use super::*;
+
+    extern crate test;
+    use self::test::Bencher;
+
+    #[bench]
+    fn bench_hamming(bencher: &mut Bencher) {
+        let a = "ACAAGATGCCATTGTCCCCCGGCCTCCTGCTGCTGCTGCTCTCCGGGG";
+        let b = "CCTGGAGGGTGGCCCCACCGGCCGAGACAGCGAGCATATGCAGGAAGC";
+        bencher.iter(|| {
+            strsim::hamming(&a, &b).unwrap();
+        })
+    }
+
+    #[bench]
+    fn bench_jaro(bencher: &mut Bencher) {
+        let a = "Philosopher Friedrich Nietzsche";
+        let b = "Philosopher Jean-Paul Sartre";
+        bencher.iter(|| {
+            strsim::jaro(&a, &b);
+        })
+    }
+
+    #[bench]
+    fn bench_jaro_winkler(bencher: &mut Bencher) {
+        let a = "Philosopher Friedrich Nietzsche";
+        let b = "Philosopher Jean-Paul Sartre";
+        bencher.iter(|| {
+            strsim::jaro_winkler(&a, &b);
+        })
+    }
+
+    #[bench]
+    fn bench_levenshtein(bencher: &mut Bencher) {
+        let a = "Philosopher Friedrich Nietzsche";
+        let b = "Philosopher Jean-Paul Sartre";
+        bencher.iter(|| {
+            strsim::levenshtein(&a, &b);
+        })
+    }
+
+    #[bench]
+    fn bench_osa_distance(bencher: &mut Bencher) {
+        let a = "Philosopher Friedrich Nietzsche";
+        let b = "Philosopher Jean-Paul Sartre";
+        bencher.iter(|| {
+            strsim::osa_distance(&a, &b);
+        })
+    }
+
+    #[bench]
+    fn bench_damerau_levenshtein(bencher: &mut Bencher) {
+        let a = "Philosopher Friedrich Nietzsche";
+        let b = "Philosopher Jean-Paul Sartre";
+        bencher.iter(|| {
+            strsim::damerau_levenshtein(&a, &b);
+        })
+    }
+}


### PR DESCRIPTION
This commit adds the file `benches/benches.rs`, containing simple benchmarks of strsim functions using the standard Rust benchmarker.

Because the benchmarker is currently unstable, it requires a Nightly toolchain to run, even though strsim targets stable. The benchmarks can be invoked via `cargo +nightly bench` -- a note about that is added to the README.md.

The sample inputs were chosen to have some similarities (to let `jaro_winkler()` show some difference) and to be medium-sized.

Running the benchmarks produces the following profile:

```
running 6 tests
test benches::bench_damerau_levenshtein ... bench:      23,082 ns/iter (+/- 6,610)
test benches::bench_hamming             ... bench:          97 ns/iter (+/- 8)
test benches::bench_jaro                ... bench:         844 ns/iter (+/- 48)
test benches::bench_jaro_winkler        ... bench:         866 ns/iter (+/- 93)
test benches::bench_levenshtein         ... bench:       2,004 ns/iter (+/- 425)
test benches::bench_osa_distance        ... bench:       3,869 ns/iter (+/- 1,134)
```

It looks like there is room for improvement, and these benchmarks allow for establishing a baseline.