### PR TITLE
Forbid unsafe code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# strsim-rs [![Crates.io](https://img.shields.io/crates/v/strsim.svg)](https://crates.io/crates/strsim) [![Crates.io](https://img.shields.io/crates/l/strsim.svg?maxAge=2592000)](https://github.com/dguo/strsim-rs/blob/master/LICENSE) [![build status](https://travis-ci.org/dguo/strsim-rs.svg?branch=master)](https://travis-ci.org/dguo/strsim-rs)
+# strsim-rs [![Crates.io](https://img.shields.io/crates/v/strsim.svg)](https://crates.io/crates/strsim) [![Crates.io](https://img.shields.io/crates/l/strsim.svg?maxAge=2592000)](https://github.com/dguo/strsim-rs/blob/master/LICENSE) [![build status](https://travis-ci.org/dguo/strsim-rs.svg?branch=master)](https://travis-ci.org/dguo/strsim-rs) [![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 
 [Rust](https://www.rust-lang.org) implementations of [string similarity metrics]:
   - [Hamming]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 //! This library implements string similarity metrics.
 
+#[forbid(unsafe_code)]
+
 use std::char;
 use std::cmp::{max, min};
 use std::collections::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! This library implements string similarity metrics.
 
-#[forbid(unsafe_code)]
+#![forbid(unsafe_code)]
 
 use std::char;
 use std::cmp::{max, min};


### PR DESCRIPTION
`#![forbid(unsafe_code)]` annotation makes rustc abort compilation if there are any unsafe blocks in the crate.

Presence of this annotation is picked up by tools such as [cargo-geiger](https://github.com/anderejd/cargo-geiger) and lets them ensure that there is indeed no unsafe code as opposed to something they couldn't detect (e.g. unsafe added via macro expansion, etc).

This also adds a badge advertising that unsafe code is forbidden. Being 100% safe is a desirable property for a crate and should be advertised. The badge currently links to Secure Code WG's community outreach repo, but I'm fine with changing the link or making the badge non-clickable.