### PR TITLE
Remove 1.31.0 from the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: ["macos-latest", "ubuntu-latest", "windows-latest"]
-        rust: ["beta", "stable", "1.31.0"]
+        rust: ["beta", "stable"]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
We got a compilation error on https://github.com/dguo/strsim-rs/pull/54, and I found [this thread](https://internals.rust-lang.org/t/should-i-expect-rust-1-28-1-30-to-support-building-on-macos-12/17713). Let's just test on stable and beta.