### PR TITLE
reimplement damerau levenshtein distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ This project attempts to adhere to [Semantic Versioning](http://semver.org).
 
 - reduce binary size of Levenshtein distance
 
+- improve Damerau-Levenshtein implementation
+  - reduce memory usage from `O(N*M)` to `O(N+M)`
+  - reduce runtime in our own benchmark by more than `70%`
+  - reduce binary size by more than `25%`
+
 ### Fixed
 
 - Fix transposition counting in Jaro and Jaro-Winkler.


### PR DESCRIPTION
This reimplements the damerau levenshtein distance based on the paper `Linear space string correction algorithm using the Damerau-Levenshtein distance` from Chunchun Zhao and Sartaj Sahni. In addition it uses a custom hashmap which is both smaller and faster for this workload.

This leads to the following improvements:
- reduced memory usage from O(N*M) to O(N+M)
- reduces runtime in our own benchmark by more than 70%
- reduces binary size by more than 25%


This is based on #57 and only implements the new algorithm for strings, while the generic version continues to use the old version. For strings this is better in all regards, while for the generic version it's not as simply:
- when using the same custom hashmap we would no longer support arbitrary hashable items
- when using it with the standard hashmap the performance is not drastically better, but the binary size is larger.

Since here we want to focus on binary size I would just recommend rapidfuzz-rs for users who really care about performance for now. I will probably take another stab at this at some point, but the string version should be more important for users anyways.

For reference here is a binary size report for the string version:
Before the change:
```
File  .text     Size Crate
5.7%  95.7% 258.0KiB std
0.1%   2.4%   6.5KiB strsim
0.0%   0.0%     119B strsim_test
0.0%   0.0%     102B [Unknown]
5.9% 100.0% 269.6KiB .text section size, the file size is 4.4MiB
```
After the change:
```
File  .text     Size Crate
5.6%  96.2% 255.6KiB std
0.1%   1.9%   5.0KiB strsim
0.0%   0.0%     119B strsim_test
0.0%   0.0%     102B [Unknown]
5.9% 100.0% 265.6KiB .text section size, the file size is 4.4MiB
```