### PR TITLE
Improve Osa implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project attempts to adhere to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- improve OSA implementation
+  - reduce runtime
+  - reduce binary size by more than `25%`
+
 ### Fixed
 
 - Fix transposition counting in Jaro and Jaro-Winkler.


### PR DESCRIPTION
This reduces the binary size of osa_distance by more than 25% while improving the performance.

Binary size before change:
```
File .text   Size  Crate Name
0.0%  0.7% 1.9KiB strsim strsim::osa_distance2
0.0%  0.1%   199B strsim alloc::raw_vec::RawVec<T,A>::reserve::do_reserve_and_handle
0.0%  0.1%   140B strsim alloc::raw_vec::finish_grow
0.0%  0.0%    28B strsim core::ptr::drop_in_place<alloc::vec::Vec<usize>>
0.0%  0.0%     0B        And 0 smaller methods. Use -n N to show more.
0.1%  0.9% 2.3KiB        filtered data size, the file size is 4.4MiB
```
Binary size after the change:
```
File .text   Size  Crate Name
0.0%  0.6% 1.7KiB strsim strsim::osa_distance
0.0%  0.0%    28B strsim core::ptr::drop_in_place<alloc::vec::Vec<usize>>
0.0%  0.0%     0B        And 0 smaller methods. Use -n N to show more.
0.0%  0.7% 1.7KiB        filtered data size, the file size is 4.4MiB
```

The following graph shows the runtime for random strings of different lengths:

![image](https://github.com/dguo/strsim-rs/assets/44199644/6ce4611f-c553-4d98-8f3f-632bc4cb8287)

