### PR TITLE
Remove cloning in generic_damerau_levenshtein

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,7 +352,7 @@ fn flat_index(i: usize, j: usize, width: usize) -> usize {
 /// ```
 pub fn generic_damerau_levenshtein<Elem>(a_elems: &[Elem], b_elems: &[Elem]) -> usize
 where
-    Elem: Eq + Hash + Clone,
+    Elem: Eq + Hash,
 {
     let a_len = a_elems.len();
     let b_len = b_elems.len();
@@ -379,7 +379,7 @@ where
         distances[flat_index(1, j + 1, width)] = j;
     }
 
-    let mut elems: HashMap<Elem, usize> = HashMap::with_capacity(64);
+    let mut elems: HashMap<&Elem, usize> = HashMap::with_capacity(64);
 
     for i in 1..(a_len + 1) {
         let mut db = 0;
@@ -407,7 +407,7 @@ where
             );
         }
 
-        elems.insert(a_elems[i - 1].clone(), i);
+        elems.insert(&a_elems[i - 1], i);
     }
 
     distances[flat_index(a_len + 1, b_len + 1, width)]


### PR DESCRIPTION
Hi there! This PR modifies the `generic_damerau_levenshtein` implementation to:

- Use borrowed elements (`&Elem`) as `HashMap` keys instead of owned values
- Eliminate unnecessary `.clone()` calls
- Allow broader use cases for types where cloning is expensive or impossible

Benefits:
- Faster execution
- Supports non-Clone element types
- Reduces memory allocations